### PR TITLE
feat: Add mmap trace

### DIFF
--- a/include/uapi/linux/ptrace.h
+++ b/include/uapi/linux/ptrace.h
@@ -147,8 +147,11 @@ struct ptrace_rseq_configuration {
 #define PTRACE_O_EXITKILL		(1 << 20)
 #define PTRACE_O_SUSPEND_SECCOMP	(1 << 21)
 
+/* additional option for spidermine: MMAPTRACE */
+#define PTRACE_O_MMAPTRACE      (1 << 22)
+
 #define PTRACE_O_MASK		(\
-	0x000000ff | PTRACE_O_EXITKILL | PTRACE_O_SUSPEND_SECCOMP)
+	0x000000ff | PTRACE_O_EXITKILL | PTRACE_O_SUSPEND_SECCOMP | PTRACE_O_MMAPTRACE)
 
 #include <asm/ptrace.h>
 

--- a/kernel/entry/common.c
+++ b/kernel/entry/common.c
@@ -89,7 +89,7 @@ static __always_inline long
 __syscall_enter_from_user_work(struct pt_regs *regs, long syscall)
 {
 	unsigned long work = READ_ONCE(current_thread_info()->syscall_work);
-	
+
 	if (work & SYSCALL_WORK_ENTER)
 		/* additional option for spidermine: handling trace */
 		if (current->ptrace & PT_MMAPTRACE && syscall == __NR_mmap)

--- a/kernel/entry/common.c
+++ b/kernel/entry/common.c
@@ -89,8 +89,11 @@ static __always_inline long
 __syscall_enter_from_user_work(struct pt_regs *regs, long syscall)
 {
 	unsigned long work = READ_ONCE(current_thread_info()->syscall_work);
-
+	
 	if (work & SYSCALL_WORK_ENTER)
+		/* additional option for spidermine: handling trace */
+		if (current->ptrace & PT_MMAPTRACE && syscall == __NR_mmap)
+			return syscall;
 		syscall = syscall_trace_enter(regs, syscall, work);
 
 	return syscall;
@@ -245,11 +248,19 @@ static void syscall_exit_work(struct pt_regs *regs, unsigned long work)
 	audit_syscall_exit(regs);
 
 	if (work & SYSCALL_WORK_SYSCALL_TRACEPOINT)
-		trace_sys_exit(regs, syscall_get_return_value(current, regs));
+		/* additional option for spidermine: handling mmap trace */
+		if (current->ptrace == PT_MMAPTRACE && regs->orig_ax == __NR_mmap)
+			trace_sys_exit(regs, syscall_get_return_value(current, regs));
+		else
+			trace_sys_exit(regs, syscall_get_return_value(current, regs));
 
 	step = report_single_step(work);
 	if (step || work & SYSCALL_WORK_SYSCALL_TRACE)
-		ptrace_report_syscall_exit(regs, step);
+		/* additional option for spidermine: handling mmap trace */
+		if (current->ptrace == PT_MMAPTRACE && regs->orig_ax == __NR_mmap)
+			ptrace_report_syscall_exit(regs, step);
+		else 
+			ptrace_report_syscall_exit(regs, step);
 }
 
 /*


### PR DESCRIPTION
## Summary
* `mmap tracer` was added for spidermine logic implementation.

## Category
- [x] A new feature
- [ ] A bug fix
- [ ] Code convention, style
- [ ] Refactoring production code
- [ ] docs
- [ ] Cicd, Automation
- [ ] Chore, others

## Description of features implemented

An eventless option called `PTRACE_O_MMAPTRACE` was added to line 139 of the file `include/uapi/linux/ptrace.h` and shifted 22 times. Add eventless option as _OR_ operator to `PTRACE_O_MASK`.

If the `PT_MMAPTRACE` flag exists in the `current->ptrae` at the entry of the syscall and the called systemcall is not `mmap()`, return syscall without calling the `syscall_trace_enter()` and exit the `__syscall_enter_from_user_work()`.

If the `PT_MMAPTRACE` flag exists in the `current->ptrae` at the end of the syscall and the called systemcall is not `mmap()`, exit the `syscall_exit_work()` without calling the `trace_sys_exit()` and `ptrace_report_syscall_exit()`.